### PR TITLE
Use script-specific requirements file in Update Cat gallery workflow

### DIFF
--- a/.github/workflows/update-cat-gallery.yml
+++ b/.github/workflows/update-cat-gallery.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: '3.13'
 
-      - run: pip install -r scripts/requirements.txt
+      - run: pip install -r scripts/requirements/generate_gallery.txt
 
       - run: python scripts/generate_gallery.py
       


### PR DESCRIPTION
### Motivation
- The gallery workflow was failing during dependency installation because the aggregate `scripts/requirements.txt` references a non-existent relative include, so the job must install the script-specific requirements directly.

### Description
- Updated `.github/workflows/update-cat-gallery.yml` to run `pip install -r scripts/requirements/generate_gallery.txt` instead of `pip install -r scripts/requirements.txt`.

### Testing
- Verified the workflow change by inspecting the workflow diff with `git diff -- .github/workflows/update-cat-gallery.yml` and printing the updated region with `nl -ba .github/workflows/update-cat-gallery.yml | sed -n '20,45p'`, both showing the corrected requirements path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6db668f54832fbcc02a58dff11f46)