### PR TITLE
Update LLM review workflow to GPT-5.5

### DIFF
--- a/.github/workflows/review-cat-images-with-llm.yml
+++ b/.github/workflows/review-cat-images-with-llm.yml
@@ -1,4 +1,4 @@
-name: Review cat images in PR with GPT-5.4
+name: Review cat images in PR with GPT-5.5
 
 on:
   pull_request_target:
@@ -60,7 +60,7 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Generate GPT-5.4 cat review
+      - name: Generate GPT-5.5 cat review
         id: review
         if: steps.changes.outputs.png_files != ''
         env:
@@ -146,7 +146,7 @@ jobs:
               )
 
               payload = {
-                  "model": "gpt-5.4",
+                  "model": "gpt-5.5",
                   "input": [
                       {
                           "role": "user",
@@ -189,7 +189,7 @@ jobs:
               marker,
               "## LLM Cat Image Review",
               "",
-              "_This pull request review was performed by an LLM using GPT-5.4. Treat it as automated feedback, not a final human approval._",
+              "_This pull request review was performed by an LLM using GPT-5.5. Treat it as automated feedback, not a final human approval._",
               "",
           ]
 
@@ -205,7 +205,7 @@ jobs:
                       "",
                       f"![Submitted cat image]({raw_url(os.environ['HEAD_REPO'], os.environ['HEAD_SHA'], review['cat_path'])})",
                       "",
-                      "**GPT-5.4 review**",
+                      "**GPT-5.5 review**",
                       "",
                       review["review_text"],
                       "",


### PR DESCRIPTION
### Motivation
- Switch the PR cat image review workflow to use the newer `gpt-5.5` model so generated reviews and labels reflect the updated LLM target.

### Description
- Updated `.github/workflows/review-cat-images-with-llm.yml` to rename the workflow/step labels and replace the OpenAI Responses API payload `model` value and generated comment text from `gpt-5.4` to `gpt-5.5`.

### Testing
- Verified the change by inspecting the workflow diff and file content with `git status --short`, `git diff -- .github/workflows/review-cat-images-with-llm.yml`, and `nl -ba .github/workflows/review-cat-images-with-llm.yml | sed -n '1,230p'`, all of which showed the expected updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2964ab25c832fa04ff19afa786b0f)